### PR TITLE
Add configurable bot parameters

### DIFF
--- a/recomendo-instagram/contentscript.js
+++ b/recomendo-instagram/contentscript.js
@@ -1,10 +1,11 @@
 // === CONFIGURAÇÕES DO USUÁRIO ===
-const MIN_DELAY = 30000; // 30 segundos
-const MAX_DELAY = 300000; // 5 minutos
+let MIN_DELAY = 30000; // 30 segundos
+let MAX_DELAY = 300000; // 5 minutos
 const DELAY_CURTIDA = 3000; // Delay entre curtidas
 const TEMPO_ESPERA_ENTRE_ACOES = 7000; // Delay entre seguir e curtir, etc.
-const MAX_CURTIDAS = 4; // Configurável entre 0 e 4
+let MAX_CURTIDAS = 4; // Configurável entre 0 e 4
 
+let MAX_PERFIS = Infinity; // Número máximo de perfis a seguir
 // === VARIÁVEIS ===
 let parar = false;
 const logBox = document.createElement('div');
@@ -126,15 +127,24 @@ async function iniciar() {
   if (!modal) return log('⚠️ Modal de seguidores não encontrado');
 
   const botoes = [...modal.querySelectorAll('button')].filter(btn => btn.innerText.toLowerCase() === 'seguir');
-
+  let count = 0;
   for (const botao of botoes) {
-    if (parar) break;
+    if (parar || count >= MAX_PERFIS) break;
     const delay = delayAleatorio(MIN_DELAY, MAX_DELAY);
     await processarPerfil(botao);
+    count++;
     log(`⏳ Próxima ação em: ${(delay / 1000).toFixed(0)}s`);
     await esperar(delay);
   }
   log('✅ Fim da automação');
 }
 
-iniciar();
+chrome.runtime.onMessage.addListener((request) => {
+  if (request.type === 'config') {
+    MAX_PERFIS = request.data.maxPerfis;
+    MAX_CURTIDAS = request.data.maxCurtidas;
+    MIN_DELAY = request.data.minDelay * 1000;
+    MAX_DELAY = request.data.maxDelay * 1000;
+    iniciar();
+  }
+});

--- a/recomendo-instagram/popup.html
+++ b/recomendo-instagram/popup.html
@@ -20,6 +20,22 @@
 </head>
 <body>
   <h3>Recomendo Instagram</h3>
+  <label>Nº máx. de perfis por sessão:<br>
+    <input id="maxPerfis" type="number" min="1" value="10" style="width:100%">
+  </label>
+  <br>
+  <label>Qtd. de fotos para curtir (0-4):<br>
+    <input id="maxCurtidas" type="number" min="0" max="4" value="1" style="width:100%">
+  </label>
+  <br>
+  <label>Delay mínimo (s):<br>
+    <input id="minDelay" type="number" min="0" value="30" style="width:100%">
+  </label>
+  <br>
+  <label>Delay máximo (s):<br>
+    <input id="maxDelay" type="number" min="0" value="60" style="width:100%">
+  </label>
+  <div id="error" style="color:red;margin-top:5px;"></div>
   <button id="iniciarBot">Iniciar Bot</button>
   <script src="popup.js"></script>
 </body>

--- a/recomendo-instagram/popup.js
+++ b/recomendo-instagram/popup.js
@@ -1,8 +1,37 @@
+function mostrarErro(msg) {
+  document.getElementById("error").textContent = msg;
+}
+
 document.getElementById("iniciarBot").addEventListener("click", () => {
+  const maxPerfis = parseInt(document.getElementById("maxPerfis").value, 10);
+  const maxCurtidas = parseInt(document.getElementById("maxCurtidas").value, 10);
+  const minDelay = parseInt(document.getElementById("minDelay").value, 10);
+  const maxDelay = parseInt(document.getElementById("maxDelay").value, 10);
+
+  mostrarErro("");
+
+  if (isNaN(maxPerfis) || maxPerfis <= 0) {
+    return mostrarErro("Número de perfis inválido");
+  }
+  if (isNaN(maxCurtidas) || maxCurtidas < 0 || maxCurtidas > 4) {
+    return mostrarErro("Fotos para curtir deve ser 0-4");
+  }
+  if (isNaN(minDelay) || minDelay < 0) {
+    return mostrarErro("Delay mínimo inválido");
+  }
+  if (isNaN(maxDelay) || maxDelay < minDelay) {
+    return mostrarErro("Delay máximo deve ser >= mínimo");
+  }
+
+  const config = { maxPerfis, maxCurtidas, minDelay, maxDelay };
+
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    const tabId = tabs[0].id;
     chrome.scripting.executeScript({
-      target: { tabId: tabs[0].id },
+      target: { tabId },
       files: ["contentscript.js"]
+    }, () => {
+      chrome.tabs.sendMessage(tabId, { type: "config", data: config });
     });
   });
 });


### PR DESCRIPTION
## Summary
- enable configuration of bot parameters in popup
- validate settings in popup.js
- pass settings to contentscript via messaging
- handle settings and limits inside contentscript

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882e9d7d4e4832bba5b2fd18c2e74fc