### PR TITLE
Implement skip for already followed profiles

### DIFF
--- a/recomendo-instagram/contentscript.js
+++ b/recomendo-instagram/contentscript.js
@@ -119,6 +119,16 @@ async function processarPerfil(botao) {
     ?.getAttribute('href')
     ?.split('/')?.[3];
 
+  const textoBotao = botao.innerText?.toLowerCase();
+
+  if (textoBotao === 'seguindo' || textoBotao === 'solicitado') {
+    log(`⚠️ Perfil já seguido ou solicitado: @${nomePerfil}`);
+    const modal = botao.closest('div[role="dialog"]');
+    modal?.scrollBy(0, 200);
+    await esperar(500);
+    return;
+  }
+
   if (perfisSeguidos.has(nomePerfil)) {
     log(`⚠️ Perfil já processado: ${nomePerfil}`);
     return;


### PR DESCRIPTION
## Summary
- skip profiles with Seguindo/Solicitado status
- log info and scroll modal when skipping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883b5b6a988832b81e2f0b9f046ab06