### PR TITLE
Fix profile link extraction in Instagram automation

### DIFF
--- a/recomendo-instagram/contentscript.js
+++ b/recomendo-instagram/contentscript.js
@@ -136,21 +136,26 @@ async function voltarParaModal() {
 }
 
 function extrairNomeDoPerfil(botao) {
-  const item = botao.closest('li, div');
+  const item = botao.closest('li') || botao.closest('div');
   if (!item) return { item: null, link: null, nome: null };
+
   let linkPerfil = item.querySelector('a[href^="/"]');
   if (!linkPerfil) {
     linkPerfil = item.querySelector('a[href*="instagram.com"]');
   }
+
   if (!linkPerfil) {
     log('⚠️ Link do perfil não encontrado');
+    log(item.outerHTML);
     return { item, link: null, nome: null };
   }
+
   const hrefCompleto = linkPerfil.getAttribute('href') || linkPerfil.href;
   if (!hrefCompleto) {
     log('⚠️ Link do perfil sem href');
     return { item, link: linkPerfil, nome: null };
   }
+
   const hrefSemQuery = hrefCompleto.split('?')[0];
   const partes = hrefSemQuery.split('/').filter(Boolean);
   const nome = partes[partes.length - 1] || null;


### PR DESCRIPTION
## Summary
- update `extrairNomeDoPerfil` to search from the nearest list item
- log `item.outerHTML` when no profile link is found for debugging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883e5ca7da0832bb973d1bf0c1d75ac