### PR TITLE
Improve follower modal reopening

### DIFF
--- a/recomendo-instagram/contentscript.js
+++ b/recomendo-instagram/contentscript.js
@@ -132,6 +132,21 @@ async function curtirFotos() {
 async function voltarParaModal() {
   history.back();
   await esperar(TEMPO_ESPERA_ENTRE_ACOES * 2);
+
+  let modal = getFollowerModal();
+  if (!modal) {
+    const abrirLink = select('a[href$="/followers/"]');
+    if (abrirLink) {
+      abrirLink.click();
+      await esperar(TEMPO_ESPERA_ENTRE_ACOES * 2);
+      modal = getFollowerModal();
+    }
+    if (!modal) {
+      log('⚠️ Falha ao reabrir a lista de seguidores');
+      return;
+    }
+  }
+
   log('⬅️ Voltou para lista de seguidores');
 }
 


### PR DESCRIPTION
## Summary
- handle case where follower modal disappears when returning from profile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68842d411240832bb33dd27bfbe76fb0