### PR TITLE
Improve scroll detection and document modal usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This repository contains a small Chrome extension used for automating interactio
 
 1. Load the `recomendo-instagram` directory as an unpacked extension in Chrome.
 2. Open Instagram and click the extension icon.
-3. In the popup, click **Iniciar Bot** to run the automation.
+3. Navegue até o perfil desejado e clique em **seguidores** (ou **seguindo**) para abrir o modal de listas.
+4. Com o modal de seguidores visível, clique em **Iniciar Bot** na popup para iniciar a automação.
 
 The extension logs actions directly on the page and provides a button to stop the automation at any time.
 

--- a/recomendo-instagram/contentscript.js
+++ b/recomendo-instagram/contentscript.js
@@ -76,24 +76,32 @@ const SELECTOR_MODAL = 'div[role="dialog"]';
 
 const getFollowerModal = () => select(SELECTOR_MODAL);
 
+function getScrollableContainer(modal) {
+  if (!modal) return null;
+  const elements = [modal, ...modal.querySelectorAll('*')];
+  for (const el of elements) {
+    const style = getComputedStyle(el);
+    if (
+      (style.overflowY === 'auto' || style.overflowY === 'scroll') &&
+      el.scrollHeight > el.clientHeight
+    ) {
+      return el;
+    }
+  }
+  return modal;
+}
+
 function delayAleatorio(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
 async function scrollModal(modal = getFollowerModal()) {
   if (!modal) return;
-  const container =
-    select('.isgrP', modal) ||
-    // fallback to any child with vertical overflow
-    select('[style*="overflow-y"]', modal) ||
-    modal;
+  const container = getScrollableContainer(modal);
   let previous = modal.querySelectorAll('button').length;
   let attempts = 0;
   do {
-    const distance =
-      container.scrollHeight - container.scrollTop - container.clientHeight;
-    const amount = distance > 0 ? distance : container.clientHeight;
-    container.scrollBy({ top: amount, behavior: 'smooth' });
+    container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
     await esperar(delayAleatorio(1000, 6000));
     attempts++;
   } while (


### PR DESCRIPTION
## Summary
- better detect scrollable container in `scrollModal`
- always scroll to bottom with `scrollTo`
- clarify that the followers modal must be open before starting the bot

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688411072cc4832ba60f9be1d9803563