### PR TITLE
Improve liking reliability by scrolling profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,8 @@ This repository contains a small Chrome extension used for automating interactio
 
 The extension logs actions directly on the page and provides a button to stop the automation at any time.
 
+When visiting a profile the bot now scrolls the page a few times before liking
+posts. This ensures that enough posts are loaded in cases where Instagram uses
+lazy loading.
+
 Use responsibly and at your own risk.

--- a/recomendo-instagram/contentscript.js
+++ b/recomendo-instagram/contentscript.js
@@ -110,6 +110,19 @@ async function scrollModal(modal = getFollowerModal()) {
   );
 }
 
+async function scrollProfile() {
+  let iterations = 0;
+  do {
+    window.scrollTo(0, document.body.scrollHeight);
+    await esperar(delayAleatorio(500, 1500));
+    const posts = [...document.querySelectorAll('article a')].filter((a) =>
+      a.href.includes('/p/')
+    );
+    if (posts.length >= config.maxCurtidas) break;
+    iterations++;
+  } while (iterations < 3);
+}
+
 async function clicarBotaoSeguir(botao, perfil) {
   if (!botao) return false;
   const texto = botao.innerText.toLowerCase();
@@ -125,15 +138,16 @@ async function clicarBotaoSeguir(botao, perfil) {
 }
 
 async function curtirFotos() {
-  const links = [...document.querySelectorAll('article a')].filter((a) => a.href.includes('/p/'));
-  const fotosCurtidas = Math.min(
-    links.length,
-    Math.floor(Math.random() * (config.maxCurtidas + 1))
-  );
-  for (let i = 0; i < fotosCurtidas; i++) {
-    if (parar) return 0;
+  const maxCurtidas = Math.floor(Math.random() * (config.maxCurtidas + 1));
+  let curtidas = 0;
+  while (curtidas < maxCurtidas) {
+    const links = [...document.querySelectorAll('article a')].filter((a) =>
+      a.href.includes('/p/')
+    );
+    if (curtidas >= links.length) break;
+    if (parar) return curtidas;
     try {
-      links[i].click();
+      links[curtidas].click();
       await esperar(TEMPO_ESPERA_ENTRE_ACOES);
       const botaoLike = select('svg[aria-label="Curtir"], svg[aria-label="Like"]');
       botaoLike?.closest('button')?.click();
@@ -143,9 +157,10 @@ async function curtirFotos() {
     } catch (err) {
       log('⚠️ Erro ao curtir foto');
     }
+    curtidas++;
     await esperar(DELAY_CURTIDA);
   }
-  return fotosCurtidas;
+  return curtidas;
 }
 
 async function voltarParaModal() {
@@ -253,6 +268,7 @@ async function processarPerfil(botao) {
   await clicarBotaoSeguir(seguirBtn, nomePerfil);
 
   await esperar(TEMPO_ESPERA_ENTRE_ACOES);
+  await scrollProfile();
   const curtidas = await curtirFotos();
   log(`❤️ @${nomePerfil}: curtiu ${curtidas} foto(s)`);
 


### PR DESCRIPTION
## Summary
- ensure more posts are visible by adding `scrollProfile`
- scroll profile page before attempting to like posts
- refresh post list during likes
- document new behaviour

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68844acfcdf0832bb8f9ea9395854c5d