### PR TITLE
Improve popup design and logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,8 @@ When visiting a profile the bot now scrolls the page a few times before liking
 posts. This ensures that enough posts are loaded in cases where Instagram uses
 lazy loading.
 
+The popup menu received a small visual overhaul and the in-page log panel now
+colorizes messages. Logs are also forwarded to the extension background for easy
+viewing in the browser console.
+
 Use responsibly and at your own risk.

--- a/recomendo-instagram/contentscript.js
+++ b/recomendo-instagram/contentscript.js
@@ -26,14 +26,16 @@ function criarPainel() {
     position: fixed;
     bottom: 10px;
     right: 10px;
-    background: #000;
+    background: rgba(0,0,0,0.8);
     color: lime;
     font-family: monospace;
-    font-size: 12px;
+    font-size: 13px;
     padding: 10px;
     max-height: 200px;
+    width: 240px;
     overflow-y: auto;
     z-index: 9999;
+    box-shadow: 0 0 6px rgba(0,0,0,0.5);
   `;
   document.body.appendChild(logBox);
   log('✅ Iniciando automação...');
@@ -47,12 +49,14 @@ function addBotaoParar() {
     position: fixed;
     bottom: 10px;
     left: 10px;
-    background: red;
+    background: #d9534f;
     color: white;
     border: none;
-    padding: 10px;
+    padding: 10px 12px;
     z-index: 9999;
     font-weight: bold;
+    cursor: pointer;
+    box-shadow: 0 0 4px rgba(0,0,0,0.3);
   `;
   btn.onclick = () => parar = true;
   document.body.appendChild(btn);
@@ -63,8 +67,16 @@ function log(msg) {
   const linha = document.createElement('div');
   linha.textContent = `[${tempo}] ${msg}`;
   linha.style.marginBottom = '4px';
+
+  if (/⚠️|❌/.test(msg)) linha.style.color = 'orange';
+  if (/✅|❤️/.test(msg)) linha.style.color = 'lime';
+
   logBox.appendChild(linha);
   logBox.scrollTop = logBox.scrollHeight;
+
+  try {
+    chrome.runtime.sendMessage({ tipo: 'log', msg });
+  } catch (_) {}
 }
 
 // === FUNÇÕES ===

--- a/recomendo-instagram/popup.html
+++ b/recomendo-instagram/popup.html
@@ -6,37 +6,61 @@
     body {
       font-family: sans-serif;
       margin: 0;
-      padding: 20px;
+      padding: 15px;
+      width: 220px;
     }
+
+    label {
+      display: block;
+      font-size: 14px;
+      margin-bottom: 8px;
+    }
+
+    input {
+      width: 100%;
+      margin-top: 4px;
+      box-sizing: border-box;
+    }
+
     #iniciarBot {
-      background: #00aaff;
-      color: white;
+      background: #0095f6;
+      color: #fff;
       border: none;
-      padding: 10px;
+      padding: 8px;
       width: 100%;
       font-weight: bold;
       cursor: pointer;
+      margin-top: 10px;
+    }
+
+    #iniciarBot:hover {
+      background: #007acc;
+    }
+
+    #error {
+      color: red;
+      margin-top: 5px;
     }
   </style>
 </head>
 <body>
   <h3>Recomendo Instagram</h3>
   <label>Nº máx. de perfis por sessão:<br>
-    <input id="maxPerfis" type="number" min="1" value="10" style="width:100%">
+    <input id="maxPerfis" type="number" min="1" value="10" placeholder="10">
   </label>
   <br>
   <label>Qtd. de fotos para curtir (0-4):<br>
-    <input id="maxCurtidas" type="number" min="0" max="4" value="1" style="width:100%">
+    <input id="maxCurtidas" type="number" min="0" max="4" value="1" placeholder="1">
   </label>
   <br>
   <label>Delay mínimo (s):<br>
-    <input id="minDelay" type="number" min="0" value="30" style="width:100%">
+    <input id="minDelay" type="number" min="0" value="30" placeholder="30">
   </label>
   <br>
   <label>Delay máximo (s):<br>
-    <input id="maxDelay" type="number" min="0" value="60" style="width:100%">
+    <input id="maxDelay" type="number" min="0" value="60" placeholder="60">
   </label>
-  <div id="error" style="color:red;margin-top:5px;"></div>
+  <div id="error"></div>
   <button id="iniciarBot">Iniciar Bot</button>
   <script src="popup.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- make popup menu easier to read with some CSS tweaks
- colorize log messages and send them to the background
- make log panel and stop button styling nicer
- document visual changes in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68844a1d7a24832b9d37c63ee258bff3