### PR TITLE
Fix follow navigation and remove duplicate checks

### DIFF
--- a/recomendo-instagram/contentscript.js
+++ b/recomendo-instagram/contentscript.js
@@ -153,7 +153,12 @@ async function processarPerfil(botao) {
   if (!nome || perfisSeguidos.has(nome)) return false;
   perfisSeguidos.add(nome);
 
-  botao.click();
+  const linkPerfil = item?.querySelector('a');
+  if (linkPerfil) {
+    linkPerfil.click();
+  } else {
+    botao.click();
+  }
   await esperar(TEMPO_ESPERA_ENTRE_ACOES * 2);
 
   log(`➡️ Visitando: @${nome}`);
@@ -178,23 +183,16 @@ while (
   tentativas++;
 }
 
-if (
-  txt.includes('seguindo') ||
-  txt.includes('solicitado') ||
-  txt.includes('following') ||
-  txt.includes('requested')
-) {
-  registrarSucessoSeguir();
-} else {
-  registrarFalhaSeguir();
-}
-
-
-    if (txt.includes('seguindo') || txt.includes('solicitado') || txt.includes('following') || txt.includes('requested')) {
-      registrarSucessoSeguir();
-    } else {
-      registrarFalhaSeguir();
-    }
+  if (
+    txt.includes('seguindo') ||
+    txt.includes('solicitado') ||
+    txt.includes('following') ||
+    txt.includes('requested')
+  ) {
+    registrarSucessoSeguir();
+  } else {
+    registrarFalhaSeguir();
+  }
   }
 
   await esperar(TEMPO_ESPERA_ENTRE_ACOES);


### PR DESCRIPTION
## Summary
- open profile link when processing a follower instead of clicking the follow button
- remove duplicate success/failure check after clicking follow

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6885124fdd18832b82f953a50c3e7543