### PR TITLE
Improve bot profile interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ When visiting a profile the bot now scrolls the page a few times before liking
 posts. This ensures that enough posts are loaded in cases where Instagram uses
 lazy loading.
 
+After each visit the script tries multiple times to return to the followers
+modal, reducing failures when the page navigation lags.
+
 The popup menu received a small visual overhaul and the in-page log panel now
 colorizes messages. Logs are also forwarded to the extension background for easy
 viewing in the browser console.


### PR DESCRIPTION
## Summary
- improve resilience when returning to the followers modal
- increase profile scrolling reliability and check that at least one post is loaded
- wait for profile page elements before interacting

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6885206e85cc832bb6da6179a88fcedb